### PR TITLE
Wrong error message for tempban command

### DIFF
--- a/commands/mod/tempban.js
+++ b/commands/mod/tempban.js
@@ -18,7 +18,7 @@ module.exports = {
 		const regex = args.splice(1).join(" ");
 
 		if (!message.member.hasPermission("BAN_MEMBERS")) {
-			return message.channel.send("I dont have exact perms to ban someone");
+			return message.channel.send("You dont have exact perms to ban someone");
 		}
 		if(!message.guild.me.hasPermission("BAN_MEMBERS")) {
 			return message.channel.send("I dont have permissions to ban someone");


### PR DESCRIPTION
It should tell the user they are missing the ban permission, instead of the bot saying they are missing ban members' permission.